### PR TITLE
QSP-1 Prevented Re-entrancy attacks PROTO-79

### DIFF
--- a/contracts/AlkemiEarnVerified.sol
+++ b/contracts/AlkemiEarnVerified.sol
@@ -6,8 +6,9 @@ import "./SafeToken.sol";
 import "./ChainLink.sol";
 import "./AlkemiWETH.sol";
 import "./RewardControlInterface.sol";
+import "./ReentrancyGuard.sol";
 
-contract AlkemiEarnVerified is Exponential, SafeToken {
+contract AlkemiEarnVerified is Exponential, SafeToken, ReentrancyGuard {
     uint256 internal initialInterestIndex;
     uint256 internal defaultOriginationFee;
     uint256 internal defaultCollateralRatio;
@@ -1470,6 +1471,7 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
         public
         payable
         isKYCVerifiedCustomer
+        nonReentrant
         returns (uint256)
     {
         if (paused) {
@@ -1618,6 +1620,19 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
         /////////////////////////
         // EFFECTS & INTERACTIONS
         // (No safe failures beyond this point)
+        // Save market updates
+        market.blockNumber = getBlockNumber();
+        market.totalSupply = localResults.newTotalSupply;
+        market.supplyRateMantissa = localResults.newSupplyRateMantissa;
+        market.supplyIndex = localResults.newSupplyIndex;
+        market.borrowRateMantissa = localResults.newBorrowRateMantissa;
+        market.borrowIndex = localResults.newBorrowIndex;
+
+        // Save user updates
+        localResults.startingBalance = balance.principal; // save for use in `SupplyReceived` event
+        balance.principal = localResults.userSupplyUpdated;
+        balance.interestIndex = localResults.newSupplyIndex;
+        
         if (asset != wethAddress) {
             // WETH is supplied to AlkemiEarnVerified contract in case of ETH automatically
             // We ERC-20 transfer the asset into the protocol (note: pre-conditions already checked above)
@@ -1648,25 +1663,12 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
             }
         }
 
-        // Save market updates
-        market.blockNumber = getBlockNumber();
-        market.totalSupply = localResults.newTotalSupply;
-        market.supplyRateMantissa = localResults.newSupplyRateMantissa;
-        market.supplyIndex = localResults.newSupplyIndex;
-        market.borrowRateMantissa = localResults.newBorrowRateMantissa;
-        market.borrowIndex = localResults.newBorrowIndex;
-
-        // Save user updates
-        localResults.startingBalance = balance.principal; // save for use in `SupplyReceived` event
-        balance.principal = localResults.userSupplyUpdated;
-        balance.interestIndex = localResults.newSupplyIndex;
-
         emit SupplyReceived(
             msg.sender,
             asset,
             amount,
             localResults.startingBalance,
-            localResults.userSupplyUpdated
+            balance.principal
         );
 
         return uint256(Error.NO_ERROR); // success
@@ -1695,6 +1697,7 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
      */
     function withdraw(address asset, uint256 requestedAmount)
         public
+        nonReentrant
         returns (uint256)
     {
         if (paused) {
@@ -1897,6 +1900,18 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
         /////////////////////////
         // EFFECTS & INTERACTIONS
         // (No safe failures beyond this point)
+        // Save market updates
+        market.blockNumber = getBlockNumber();
+        market.totalSupply = localResults.newTotalSupply;
+        market.supplyRateMantissa = localResults.newSupplyRateMantissa;
+        market.supplyIndex = localResults.newSupplyIndex;
+        market.borrowRateMantissa = localResults.newBorrowRateMantissa;
+        market.borrowIndex = localResults.newBorrowIndex;
+
+        // Save user updates
+        localResults.startingBalance = supplyBalance.principal; // save for use in `SupplyWithdrawn` event
+        supplyBalance.principal = localResults.userSupplyUpdated;
+        supplyBalance.interestIndex = localResults.newSupplyIndex;
 
         if (asset != wethAddress) {
             // Withdrawal should happen as Ether directly
@@ -1916,25 +1931,12 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
             }
         }
 
-        // Save market updates
-        market.blockNumber = getBlockNumber();
-        market.totalSupply = localResults.newTotalSupply;
-        market.supplyRateMantissa = localResults.newSupplyRateMantissa;
-        market.supplyIndex = localResults.newSupplyIndex;
-        market.borrowRateMantissa = localResults.newBorrowRateMantissa;
-        market.borrowIndex = localResults.newBorrowIndex;
-
-        // Save user updates
-        localResults.startingBalance = supplyBalance.principal; // save for use in `SupplyWithdrawn` event
-        supplyBalance.principal = localResults.userSupplyUpdated;
-        supplyBalance.interestIndex = localResults.newSupplyIndex;
-
         emit SupplyWithdrawn(
             msg.sender,
             asset,
             localResults.withdrawAmount,
             localResults.startingBalance,
-            localResults.userSupplyUpdated
+            supplyBalance.principal
         );
 
         return uint256(Error.NO_ERROR); // success
@@ -2170,6 +2172,7 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
     function repayBorrow(address asset, uint256 amount)
         public
         payable
+        nonReentrant
         returns (uint256)
     {
         if (paused) {
@@ -2369,6 +2372,19 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
         /////////////////////////
         // EFFECTS & INTERACTIONS
         // (No safe failures beyond this point)
+        // Save market updates
+        market.blockNumber = getBlockNumber();
+        market.totalBorrows = localResults.newTotalBorrows;
+        market.supplyRateMantissa = localResults.newSupplyRateMantissa;
+        market.supplyIndex = localResults.newSupplyIndex;
+        market.borrowRateMantissa = localResults.newBorrowRateMantissa;
+        market.borrowIndex = localResults.newBorrowIndex;
+
+        // Save user updates
+        localResults.startingBalance = borrowBalance.principal; // save for use in `BorrowRepaid` event
+        borrowBalance.principal = localResults.userBorrowUpdated;
+        borrowBalance.interestIndex = localResults.newBorrowIndex;
+
         if (asset != wethAddress) {
             // WETH is supplied to AlkemiEarnVerified contract in case of ETH automatically
             // We ERC-20 transfer the asset into the protocol (note: pre-conditions already checked above)
@@ -2406,24 +2422,11 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
             }
         }
 
-        // Save market updates
-        market.blockNumber = getBlockNumber();
-        market.totalBorrows = localResults.newTotalBorrows;
-        market.supplyRateMantissa = localResults.newSupplyRateMantissa;
-        market.supplyIndex = localResults.newSupplyIndex;
-        market.borrowRateMantissa = localResults.newBorrowRateMantissa;
-        market.borrowIndex = localResults.newBorrowIndex;
-
-        // Save user updates
-        localResults.startingBalance = borrowBalance.principal; // save for use in `BorrowRepaid` event
-        borrowBalance.principal = localResults.userBorrowUpdated;
-        borrowBalance.interestIndex = localResults.newBorrowIndex;
-
         supplyOriginationFeeAsAdmin(
             asset,
             msg.sender,
             localResults.repayAmount,
-            localResults.newSupplyIndex
+            market.supplyIndex
         );
 
         emit BorrowRepaid(
@@ -2431,7 +2434,7 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
             asset,
             localResults.repayAmount,
             localResults.startingBalance,
-            localResults.userBorrowUpdated
+            borrowBalance.principal
         );
 
         return uint256(Error.NO_ERROR); // success
@@ -2930,51 +2933,6 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
         /////////////////////////
         // EFFECTS & INTERACTIONS
         // (No safe failures beyond this point)
-
-        // We ERC-20 transfer the asset into the protocol (note: pre-conditions already checked above)
-        if (assetBorrow != wethAddress) {
-            // WETH is supplied to AlkemiEarnVerified contract in case of ETH automatically
-            revertEtherToUser(msg.sender, msg.value);
-            err = doTransferIn(
-                assetBorrow,
-                localResults.liquidator,
-                localResults.closeBorrowAmount_TargetUnderwaterAsset
-            );
-            if (err != Error.NO_ERROR) {
-                // This is safe since it's our first interaction and it didn't do anything if it failed
-                return fail(err, FailureInfo.LIQUIDATE_TRANSFER_IN_FAILED);
-            }
-        } else {
-            if (msg.value == requestedAmountClose) {
-                uint256 supplyError = supplyEther(
-                    localResults.liquidator,
-                    localResults.closeBorrowAmount_TargetUnderwaterAsset
-                );
-                //Repay excess funds
-                if (localResults.reimburseAmount > 0) {
-                    revertEtherToUser(
-                        localResults.liquidator,
-                        localResults.reimburseAmount
-                    );
-                }
-                if (supplyError != 0) {
-                    revertEtherToUser(msg.sender, msg.value);
-                    return
-                        fail(
-                            Error.WETH_ADDRESS_NOT_SET_ERROR,
-                            FailureInfo.WETH_ADDRESS_NOT_SET_ERROR
-                        );
-                }
-            } else {
-                revertEtherToUser(msg.sender, msg.value);
-                return
-                    fail(
-                        Error.ETHER_AMOUNT_MISMATCH_ERROR,
-                        FailureInfo.ETHER_AMOUNT_MISMATCH_ERROR
-                    );
-            }
-        }
-
         // Save borrow market updates
         borrowMarket.blockNumber = getBlockNumber();
         borrowMarket.totalBorrows = localResults
@@ -3022,6 +2980,50 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
         .updatedSupplyBalance_LiquidatorCollateralAsset;
         supplyBalance_LiquidatorCollateralAsset.interestIndex = localResults
         .newSupplyIndex_CollateralAsset;
+
+        // We ERC-20 transfer the asset into the protocol (note: pre-conditions already checked above)
+        if (assetBorrow != wethAddress) {
+            // WETH is supplied to AlkemiEarnVerified contract in case of ETH automatically
+            revertEtherToUser(msg.sender, msg.value);
+            err = doTransferIn(
+                assetBorrow,
+                localResults.liquidator,
+                localResults.closeBorrowAmount_TargetUnderwaterAsset
+            );
+            if (err != Error.NO_ERROR) {
+                // This is safe since it's our first interaction and it didn't do anything if it failed
+                return fail(err, FailureInfo.LIQUIDATE_TRANSFER_IN_FAILED);
+            }
+        } else {
+            if (msg.value == requestedAmountClose) {
+                uint256 supplyError = supplyEther(
+                    localResults.liquidator,
+                    localResults.closeBorrowAmount_TargetUnderwaterAsset
+                );
+                //Repay excess funds
+                if (localResults.reimburseAmount > 0) {
+                    revertEtherToUser(
+                        localResults.liquidator,
+                        localResults.reimburseAmount
+                    );
+                }
+                if (supplyError != 0) {
+                    revertEtherToUser(msg.sender, msg.value);
+                    return
+                        fail(
+                            Error.WETH_ADDRESS_NOT_SET_ERROR,
+                            FailureInfo.WETH_ADDRESS_NOT_SET_ERROR
+                        );
+                }
+            } else {
+                revertEtherToUser(msg.sender, msg.value);
+                return
+                    fail(
+                        Error.ETHER_AMOUNT_MISMATCH_ERROR,
+                        FailureInfo.ETHER_AMOUNT_MISMATCH_ERROR
+                    );
+            }
+        }
 
         supplyOriginationFeeAsAdmin(
             assetBorrow,
@@ -3249,6 +3251,7 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
     function borrow(address asset, uint256 amount)
         public
         isKYCVerifiedCustomer
+        nonReentrant
         returns (uint256)
     {
         if (paused) {
@@ -3453,6 +3456,20 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
         /////////////////////////
         // EFFECTS & INTERACTIONS
         // (No safe failures beyond this point)
+        // Save market updates
+        market.blockNumber = getBlockNumber();
+        market.totalBorrows = localResults.newTotalBorrows;
+        market.supplyRateMantissa = localResults.newSupplyRateMantissa;
+        market.supplyIndex = localResults.newSupplyIndex;
+        market.borrowRateMantissa = localResults.newBorrowRateMantissa;
+        market.borrowIndex = localResults.newBorrowIndex;
+
+        // Save user updates
+        localResults.startingBalance = borrowBalance.principal; // save for use in `BorrowTaken` event
+        borrowBalance.principal = localResults.userBorrowUpdated;
+        borrowBalance.interestIndex = localResults.newBorrowIndex;
+
+        originationFeeBalance[msg.sender][asset] += orgFeeBalance;
 
         if (asset != wethAddress) {
             // Withdrawal should happen as Ether directly
@@ -3469,28 +3486,13 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
             }
         }
 
-        // Save market updates
-        market.blockNumber = getBlockNumber();
-        market.totalBorrows = localResults.newTotalBorrows;
-        market.supplyRateMantissa = localResults.newSupplyRateMantissa;
-        market.supplyIndex = localResults.newSupplyIndex;
-        market.borrowRateMantissa = localResults.newBorrowRateMantissa;
-        market.borrowIndex = localResults.newBorrowIndex;
-
-        // Save user updates
-        localResults.startingBalance = borrowBalance.principal; // save for use in `BorrowTaken` event
-        borrowBalance.principal = localResults.userBorrowUpdated;
-        borrowBalance.interestIndex = localResults.newBorrowIndex;
-
-        originationFeeBalance[msg.sender][asset] += orgFeeBalance;
-
         emit BorrowTaken(
             msg.sender,
             asset,
             amount,
             localResults.startingBalance,
             localResults.borrowAmountWithFee,
-            localResults.userBorrowUpdated
+            borrowBalance.principal
         );
 
         return uint256(Error.NO_ERROR); // success

--- a/contracts/ReentrancyGuard.sol
+++ b/contracts/ReentrancyGuard.sol
@@ -1,0 +1,30 @@
+pragma solidity 0.4.24;
+
+
+/**
+ * @title Helps contracts guard against reentrancy attacks.
+ * @author Remco Bloemen <remco@2π.com>, Eenae <alexey@mixbytes.io>
+ * @dev If you mark a function `nonReentrant`, you should also
+ * mark it `external`.
+ */
+contract ReentrancyGuard {
+
+  /// @dev counter to allow mutex lock with only one SSTORE operation
+  uint256 private _guardCounter = 1;
+
+  /**
+   * @dev Prevents a contract from calling itself, directly or indirectly.
+   * If you mark a function `nonReentrant`, you should also
+   * mark it `external`. Calling one `nonReentrant` function from
+   * another is not supported. Instead, you can implement a
+   * `private` function doing the actual work, and an `external`
+   * wrapper marked as `nonReentrant`.
+   */
+  modifier nonReentrant() {
+    _guardCounter += 1;
+    uint256 localCounter = _guardCounter;
+    _;
+    require(localCounter == _guardCounter);
+  }
+
+}


### PR DESCRIPTION
I have re-factored the code to save market and user updates before the transfer occurs to prevent re-entrancy. Also, Openzeppelin's Re-entrancy guard has been used in Supply, Borrow, RepayBorrow and Withdraw functions to add additional security. 

Re-entrancy guard has not been implemented in LiquidateBorrow function because of contract size limitations and "Stack too deep" errors.