### PR TITLE
QSP-14 Refactored supply rate calculations for decimal units

### DIFF
--- a/contracts/AlkemiRateModel.sol
+++ b/contracts/AlkemiRateModel.sol
@@ -60,10 +60,10 @@ contract AlkemiRateModel is Exponential {
         contractName = _contractName;
         Exp memory temp1;
         Exp memory temp2;
-        Exp memory HunderedMantissa;
+        Exp memory HundredMantissa;
         Error err;
 
-        (err, HunderedMantissa) = getExp(100, 1);
+        (err, HundredMantissa) = getExp(100, 1);
 
         (err, MinRateActual) = getExp(MinRate, 100);
         (err, HealthyMinURActual) = getExp(HealthyMinUR, 100);
@@ -91,7 +91,7 @@ contract AlkemiRateModel is Exponential {
 
         // ReserveHigh = (MaxRate - HealthyMaxRate) / (100 - HealthyMaxUR);
         (err, temp1) = subExp(MaxRateActual, HealthyMaxRateActual);
-        (err, temp2) = subExp(HunderedMantissa, HealthyMaxURActual);
+        (err, temp2) = subExp(HundredMantissa, HealthyMaxURActual);
         (err, ReserveHigh) = divExp(temp1, temp2);
 
         // SpreadHigh = HealthyMaxRate - (ReserveHigh * BreakPointHigh);
@@ -112,10 +112,10 @@ contract AlkemiRateModel is Exponential {
         contractName = _contractName;
         Exp memory temp1;
         Exp memory temp2;
-        Exp memory HunderedMantissa;
+        Exp memory HundredMantissa;
         Error err;
 
-        (err, HunderedMantissa) = getExp(100, 1);
+        (err, HundredMantissa) = getExp(100, 1);
 
         (err, MinRateActual) = getExp(MinRate, 100);
         (err, HealthyMinURActual) = getExp(HealthyMinUR, 100);
@@ -143,7 +143,7 @@ contract AlkemiRateModel is Exponential {
 
         // ReserveHigh = (MaxRate - HealthyMaxRate) / (100 - HealthyMaxUR);
         (err, temp1) = subExp(MaxRateActual, HealthyMaxRateActual);
-        (err, temp2) = subExp(HunderedMantissa, HealthyMaxURActual);
+        (err, temp2) = subExp(HundredMantissa, HealthyMaxURActual);
         (err, ReserveHigh) = divExp(temp1, temp2);
 
         // SpreadHigh = HealthyMaxRate - (ReserveHigh * BreakPointHigh);
@@ -258,7 +258,7 @@ contract AlkemiRateModel is Exponential {
         return (
             IRError.NO_ERROR,
             utilizationRate,
-            Exp({mantissa: annualBorrowRateScaled / 100})
+            Exp({mantissa: annualBorrowRateScaled})
         );
     }
 
@@ -303,28 +303,30 @@ contract AlkemiRateModel is Exponential {
         assert(err1 == Error.NO_ERROR);
 
         // Next multiply this product times the borrow rate
-        (err1, temp1) = mulExp(utilizationRate0, annualBorrowRate);
+        // Borrow rate should be divided by 1e2 to get product at 1e18 scale
+        (err1, temp1) = mulExp(utilizationRate0, Exp({mantissa: annualBorrowRate.mantissa / 100}));
         // If the product of the mantissas for mulExp are both less than 2^256,
-        // then this operation will never fail. TODO: Verify.
+        // then this operation will never fail.
         // We know that borrow rate is in the interval [0, 2.25e17] from above.
         // We know that utilizationRate1 is in the interval [0, 9e21] from directly above.
         // As such, the multiplication is in the interval of [0, 2.025e39]. This is strictly
         // less than 2^256 (which is about 10e77).
         assert(err1 == Error.NO_ERROR);
 
-        (err1, temp1) = mulExp(temp1, oneMinusSpreadBasisPoints);
+        // oneMinusSpreadBasisPoints i.e.,(1 - SpreadLow) should be divided by 1e2 to get product at 1e18 scale
+        (err1, temp1) = mulExp(temp1, Exp({mantissa: oneMinusSpreadBasisPoints.mantissa / 100}));
         assert(err1 == Error.NO_ERROR);
 
         // And then divide down by the spread's denominator (basis points divisor)
         // as well as by blocks per year.
         (Error err4, Exp memory supplyRate) = divScalar(
             temp1,
-            10000 * blocksPerYear
+            blocksPerYear
         ); // basis points * blocks per year
         // divScalar only fails when divisor is zero. This is clearly not the case.
         assert(err4 == Error.NO_ERROR);
 
-        return (uint256(IRError.NO_ERROR), supplyRate.mantissa);
+        return (uint256(IRError.NO_ERROR), supplyRate.mantissa / 100);
     }
 
     /**
@@ -361,6 +363,6 @@ contract AlkemiRateModel is Exponential {
         assert(err1 == Error.NO_ERROR);
 
         // Note: mantissa is the rate scaled 1e18, which matches the expected result
-        return (uint256(IRError.NO_ERROR), borrowRate.mantissa);
+        return (uint256(IRError.NO_ERROR), borrowRate.mantissa / 100);
     }
 }


### PR DESCRIPTION
- Standardized intermediate calculations to always follow 1e18 scale
- Return values follow 1e16 scale to represent percentages
- Also corrected the spelling for 'Hundred'