### PR TITLE
QSP-25 Using EIP20Interface in Chainlink PROTO-87

### DIFF
--- a/contracts/ChainLink.sol
+++ b/contracts/ChainLink.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.4.24;
 
 import "./AggregatorV3Interface.sol";
-import "./TestTokens.sol";
+import "./EIP20Interface.sol";
 
 contract ChainLink {
     mapping(address => AggregatorV3Interface) internal priceContractMapping;
@@ -117,7 +117,7 @@ contract ChainLink {
             return 1000000000000000000;
         }
         // Capture the decimals in the ERC20 token
-        uint8 assetDecimals = TestTokens(asset).decimals();
+        uint8 assetDecimals = EIP20Interface(asset).decimals();
         if (!paused && priceContractMapping[asset] != address(0)) {
             (
                 uint80 roundID,

--- a/contracts/EIP20Interface.sol
+++ b/contracts/EIP20Interface.sol
@@ -14,6 +14,8 @@ contract EIP20Interface {
     */
     // total amount of tokens
     uint256 public totalSupply;
+    // token decimals
+    uint8 public decimals; // maximum is 18 decimals
 
     /**
      * @param _owner The address from which the balance will be retrieved


### PR DESCRIPTION
Using EIP20Interface.sol instead of TestTokens.sol to calculate asset decimals 