### PR TITLE
QSP-6 Included token prices in reward calc PROTO-90

### DIFF
--- a/contracts/RewardControl.sol
+++ b/contracts/RewardControl.sol
@@ -4,7 +4,6 @@ import "./RewardControlStorage.sol";
 import "./RewardControlInterface.sol";
 import "./ExponentialNoError.sol";
 import "./EIP20Interface.sol";
-import "./ChainLink.sol";
 
 contract RewardControl is
     RewardControlStorage,


### PR DESCRIPTION
Fixed the issue by considering Total Supply and Total Borrows in wei (ETH) terms so that the calculations consider token prices also while allocating rewards.