### PR TITLE
QSP-24 Hard cap on no. of markets PROTO-92

### DIFF
--- a/contracts/AlkemiEarnPublic.sol
+++ b/contracts/AlkemiEarnPublic.sol
@@ -171,6 +171,11 @@ contract AlkemiEarnPublic is Exponential, SafeToken {
     bool public paused;
 
     /**
+     * @dev Hard cap on the number of markets allowed
+     */
+    uint8 public MAXIMUM_NUMBER_OF_MARKETS = 16;
+
+    /**
      * The `SupplyLocalVars` struct is used internally in the `supply` function.
      *
      * To avoid solidity limits on the number of local variables we:
@@ -980,6 +985,8 @@ contract AlkemiEarnPublic is Exponential, SafeToken {
                     FailureInfo.SUPPORT_MARKET_OWNER_CHECK
                 );
         }
+        // Hard cap on the maximum number of markets allowed
+        require(collateralMarkets.length < uint256(MAXIMUM_NUMBER_OF_MARKETS),"Exceeding the max number of markets allowed");
 
         (Error err, Exp memory assetPrice) = fetchAssetPrice(asset);
         if (err != Error.NO_ERROR) {

--- a/contracts/AlkemiEarnVerified.sol
+++ b/contracts/AlkemiEarnVerified.sol
@@ -185,6 +185,11 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
     mapping(address => bool) private liquidators;
 
     /**
+     * @dev Hard cap on the number of markets allowed
+     */
+    uint8 public MAXIMUM_NUMBER_OF_MARKETS = 16;
+
+    /**
      * The `SupplyLocalVars` struct is used internally in the `supply` function.
      *
      * To avoid solidity limits on the number of local variables we:
@@ -1141,6 +1146,8 @@ contract AlkemiEarnVerified is Exponential, SafeToken {
                     FailureInfo.SUPPORT_MARKET_OWNER_CHECK
                 );
         }
+        // Hard cap on the maximum number of markets allowed
+        require(collateralMarkets.length < uint256(MAXIMUM_NUMBER_OF_MARKETS),"Exceeding the max number of markets allowed");
 
         (Error err, Exp memory assetPrice) = fetchAssetPrice(asset);
         if (err != Error.NO_ERROR) {

--- a/contracts/RewardControl.sol
+++ b/contracts/RewardControl.sol
@@ -493,6 +493,7 @@ contract RewardControl is
      */
     function addMarket(address market) external onlyOwner {
         require(!allMarketsIndex[market], "Market already exists");
+        require(allMarkets.length < uint256(MAXIMUM_NUMBER_OF_MARKETS),"Exceeding the max number of markets allowed");
         allMarketsIndex[market] = true;
         allMarkets.push(market);
         emit MarketAdded(market, allMarkets.length);

--- a/contracts/RewardControlStorage.sol
+++ b/contracts/RewardControlStorage.sol
@@ -51,4 +51,7 @@ contract RewardControlStorage {
 
     // @notice The ALK token address
     address public alkAddress;
+
+    // Hard cap on the maximum number of markets
+    uint8 public MAXIMUM_NUMBER_OF_MARKETS = 16;
 }


### PR DESCRIPTION
Have solved the issue by limiting the number of markets to 16 in AlkemiEarnVerified, AlkemiEarnPublic and RewardControl contracts